### PR TITLE
External scripts: pass/convert CGI query opts

### DIFF
--- a/docker/sampo/sampo.sh
+++ b/docker/sampo/sampo.sh
@@ -413,7 +413,7 @@ run_external_script() {
     debuggy "[$(basename "${BASH_SOURCE[0]}"):${LINENO}:${FUNCNAME[*]:0:${#FUNCNAME[@]}-1}()] running external script: $script_to_run ${args[*]}"
   fi
   retval=200
-  result="$(bash "${script_to_run}" "${args[@]}" 2>&1)" || retval=500
+  result="$("${script_to_run}" "${args[@]}" 2>&1)" || retval=500
   send_response $retval <<< "$result"
 }
 

--- a/docker/sampo/sampo.sh
+++ b/docker/sampo/sampo.sh
@@ -497,11 +497,11 @@ if [[ "$(basename "${0}")" == "sampo.sh" ]]; then
   # trap on error and print the line number and command
   trap 'die ${LINENO} "$BASH_COMMAND"' ERR
 
+  container_check
+
   if [[ "${SAMPO_DEBUG:=false}" == "true" ]]; then
     debuggy "\$SAMPO_DEBUG is set to true.  This will cause a lot of output."
   fi
-
-  container_check
 
   listen_for_requests
   # import the config file

--- a/docker/sampo/sampo.sh
+++ b/docker/sampo/sampo.sh
@@ -148,8 +148,9 @@ container_check() {
 die() {
   local lineno="${1}"
   local msg="${2}"
+  local retval=$3
   echo "**         **"
-  echo "** FAILURE ** ${0} at line $lineno: $msg"
+  echo "** FAILURE ** ${0} ($retval) at line $lineno: $msg"
   echo "**         **"
 }
 
@@ -495,7 +496,7 @@ if [[ "$(basename "${0}")" == "sampo.sh" ]]; then
   # Run cleanup function in interrupt
   trap cleanup SIGINT
   # trap on error and print the line number and command
-  trap 'die ${LINENO} "$BASH_COMMAND"' ERR
+  trap 'die ${BASH_SOURCE[0]}:${LINENO}:${FUNCNAME} "$BASH_COMMAND" $?' ERR
 
   container_check
 

--- a/docker/sampo/sampo.sh
+++ b/docker/sampo/sampo.sh
@@ -412,7 +412,9 @@ run_external_script() {
   if [[ "${SAMPO_DEBUG:=false}" == "true" ]]; then
     debuggy "[$(basename "${BASH_SOURCE[0]}"):${LINENO}:${FUNCNAME[*]:0:${#FUNCNAME[@]}-1}()] running external script: $script_to_run ${args[*]}"
   fi
-  send_response 200 < <(bash "${script_to_run}" "${args[@]}")
+  retval=200
+  result="$(bash "${script_to_run}" "${args[@]}" 2>&1)" || retval=500
+  send_response $retval <<< "$result"
 }
 
 


### PR DESCRIPTION
I would love to be able to do more with `run_external_script` than just passing the file name. In particular, I would like to pass:
- any of the `BASH_REMATCH` entries (captured groups), as in the other functions/actions
- whatever remains unmatched from the URI:
   - this might be query parameters (which we cannot capture with the `BASH_REMATCH` mechanism because we do not know the number of parameters in advance, and recursive matches like `/([^?]+)([?&][^=]+=[^&]+)*` are only captured once)
   - if that's the case, they should be converted from CGI style (i.e. `path?key=val&key=val...`) to GNU getopts style (i.e. `--key val --key val path`)

This is what this PR provides in a first workable attempt. But you might object:
1. it's not obvious when writing the `match_uri` rules how the final command line will look like:
    - if the regex itself contains grouping, that might end up as direct arg at the end of the call (even if the endpoint itself contains the parenthesis, e.g. `'^/(endpoint1|endpoint2)/...'`)
    - should the initial slash between service name and path argument be part of the argument (think absolute vs. relative paths)?
    - what if the unmatched part does not conform to CGI query parameters, or if we do not want to convert them to GNU getopts?
    - is inversing the order (optional vs. mandatory parameters) always the right thing to do?
2. passing the unmatched URI part might break other actions/functions in the code or rules by users

I'll be happy to discuss any potential improvements.